### PR TITLE
feat: add admin endpoints and dashboard actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server.js"
   },
   "eslintConfig": {
     "extends": [

--- a/server.js
+++ b/server.js
@@ -1,0 +1,96 @@
+const http = require('http');
+
+let settings = { service_fee_b2c: 0, service_fee_b2b: 0 };
+let users = [
+  { uid: '1', email: 'user1@example.com', role: 'b2c' },
+  { uid: '2', email: 'user2@example.com', role: 'b2b' },
+  { uid: '3', email: 'admin@example.com', role: 'admin' }
+];
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => data += chunk);
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(data || '{}'));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function authenticate(req) {
+  const authHeader = req.headers['authorization'] || '';
+  const token = authHeader.split(' ')[1];
+  if (!token) return null;
+  try {
+    return JSON.parse(Buffer.from(token, 'base64').toString());
+  } catch (err) {
+    return null;
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  const user = authenticate(req);
+  if (!user) {
+    res.writeHead(401, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify({ error: 'Unauthorized' }));
+  }
+  if (user.role !== 'admin') {
+    res.writeHead(403, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify({ error: 'Forbidden' }));
+  }
+
+  const url = new URL(req.url, 'http://localhost');
+
+  if (req.method === 'GET' && url.pathname === '/api/admin/settings') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify(settings));
+  }
+
+  if (req.method === 'PUT' && url.pathname === '/api/admin/settings') {
+    try {
+      const body = await parseBody(req);
+      settings = { ...settings, ...body };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(settings));
+    } catch (err) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'Invalid JSON' }));
+    }
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/admin/users') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify(users));
+  }
+
+  const userMatch = url.pathname.match(/^\/api\/admin\/users\/(.+)$/);
+  if (req.method === 'PUT' && userMatch) {
+    try {
+      const body = await parseBody(req);
+      const uid = userMatch[1];
+      const existing = users.find(u => u.uid === uid);
+      if (!existing) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'User not found' }));
+      }
+      existing.role = body.role;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(existing));
+    } catch (err) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'Invalid JSON' }));
+    }
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not Found' }));
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/App.js
+++ b/src/App.js
@@ -290,11 +290,45 @@ const AdminDashboard = ({ userToken }) => {
     }, [fetchData]);
 
     const handleSaveSettings = async () => {
-        alert('Saving settings...');
+        setError('');
+        setSuccess('');
+        try {
+            const res = await fetch(`${BACKEND_BASE_URL}/admin/settings`, {
+                method: 'PUT',
+                headers: {
+                    'Authorization': `Bearer ${userToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(settings)
+            });
+            if (!res.ok) throw new Error('Failed to save settings.');
+            const data = await res.json();
+            setSettings(data);
+            setSuccess('Settings saved successfully.');
+        } catch (err) {
+            setError(err.message);
+        }
     };
 
     const handleRoleChange = async (userId, newRole) => {
-        alert(`Changing user ${userId} to ${newRole}`);
+        setError('');
+        setSuccess('');
+        try {
+            const res = await fetch(`${BACKEND_BASE_URL}/admin/users/${userId}`, {
+                method: 'PUT',
+                headers: {
+                    'Authorization': `Bearer ${userToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ role: newRole })
+            });
+            if (!res.ok) throw new Error('Failed to update user role.');
+            const updatedUser = await res.json();
+            setUsers(prev => prev.map(u => u.uid === userId ? { ...u, role: updatedUser.role } : u));
+            setSuccess('User role updated successfully.');
+        } catch (err) {
+            setError(err.message);
+        }
     };
 
     if (loading) {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app title', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titleElement = await screen.findByText(/Shipping Label Creator/i);
+  expect(titleElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- implement admin dashboard actions to save settings and update user roles
- add minimal backend with protected admin endpoints
- adjust tests to check app title

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689a783d443c832093e9b7f47139b825