### PR TITLE
Add admin role handling and restrict dashboard access

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,26 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
 
-test('renders learn react link', () => {
+jest.mock('firebase/app', () => ({
+  __esModule: true,
+  initializeApp: jest.fn(),
+}));
+
+jest.mock('firebase/auth', () => ({
+  __esModule: true,
+  getAuth: jest.fn(() => ({})),
+  onAuthStateChanged: jest.fn((auth, callback) => {
+    callback(null);
+    return () => {};
+  }),
+  signOut: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+}));
+
+const App = require('./App').default;
+
+test('renders app title', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = await screen.findByText(/Shipping Label Creator/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- store user role from Firebase token and fall back when none is present
- show admin-only Dashboard button and gate AdminDashboard to admin users
- add test with Firebase auth mocks to verify main app renders

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689a783c5c888320a0b43776df4b5951