### PR TITLE
refactor: refresh app with light rounded ui

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -177,14 +177,14 @@ const fetchAddressSuggestions = async (query) => {
 
 const Alert = ({ type, message }) => {
     const styleConfig = {
-        warning: { bg: 'bg-yellow-100', border: 'border-yellow-500', text: 'text-yellow-700', Icon: AlertTriangle },
-        error: { bg: 'bg-red-100', border: 'border-red-500', text: 'text-red-700', Icon: XCircle },
-        success: { bg: 'bg-green-100', border: 'border-green-500', text: 'text-green-700', Icon: CheckCircle }
+        warning: { bg: 'bg-amber-50', border: 'border-amber-300', text: 'text-amber-700', Icon: AlertTriangle },
+        error: { bg: 'bg-rose-50', border: 'border-rose-300', text: 'text-rose-700', Icon: XCircle },
+        success: { bg: 'bg-emerald-50', border: 'border-emerald-300', text: 'text-emerald-700', Icon: CheckCircle }
     };
     const { bg, border, text, Icon } = styleConfig[type] || styleConfig.warning;
     if (!message) return null;
     return (
-        <div className={`${bg} border-l-4 ${border} ${text} p-4 rounded-md`} role="alert">
+        <div className={`${bg} border ${border} ${text} p-4 rounded-xl shadow-sm`} role="alert">
             <div className="flex">
                 <div className="py-1"><Icon className="h-5 w-5 mr-3" /></div>
                 <div><p className="whitespace-pre-wrap">{message}</p></div>
@@ -220,32 +220,32 @@ const LoginPage = ({ show, onClose }) => {
     };
 
     return (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-            <div className="w-full max-w-md bg-white p-8 rounded-xl shadow-2xl border border-blue-200 relative">
-                <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-gray-800">
+        <div className="fixed inset-0 bg-slate-900/30 backdrop-blur-sm flex items-center justify-center z-50">
+            <div className="w-full max-w-md bg-white/95 p-8 rounded-3xl shadow-xl border border-sky-100 relative">
+                <button onClick={onClose} className="absolute top-4 right-4 text-slate-400 hover:text-slate-600">
                     <XCircle size={24} />
                 </button>
                 <div className="text-center mb-8">
-                    <h1 className="text-3xl font-extrabold text-gray-800">
+                    <h1 className="text-3xl font-extrabold text-slate-700">
                         {isLoginView ? 'Welcome Back' : 'Create Account'}
                     </h1>
                 </div>
-                <form onSubmit={handleSubmit} className="space-y-6">
+                <form onSubmit={handleSubmit} className="space-y-6 text-left">
                     <div>
-                        <label htmlFor="email">Email Address</label>
-                        <input id="email" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} className="w-full mt-1 p-3 border rounded-lg"/>
+                        <label htmlFor="email" className="block text-sm font-medium text-slate-600">Email Address</label>
+                        <input id="email" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} className="w-full mt-1 p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400"/>
                     </div>
                     <div>
-                        <label htmlFor="password">Password</label>
-                        <input id="password" type="password" required minLength="6" value={password} onChange={(e) => setPassword(e.target.value)} className="w-full mt-1 p-3 border rounded-lg"/>
+                        <label htmlFor="password" className="block text-sm font-medium text-slate-600">Password</label>
+                        <input id="password" type="password" required minLength="6" value={password} onChange={(e) => setPassword(e.target.value)} className="w-full mt-1 p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400"/>
                     </div>
                     {error && <p className="text-sm text-red-600">{error}</p>}
-                    <button type="submit" disabled={loading} className="w-full flex justify-center py-3 px-4 rounded-lg text-lg font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400">
+                    <button type="submit" disabled={loading} className="w-full flex justify-center py-3 px-4 rounded-xl text-lg font-semibold text-white bg-sky-500 hover:bg-sky-400 disabled:bg-slate-300 disabled:text-slate-500 transition-colors">
                         {loading ? 'Processing...' : (isLoginView ? 'Sign In' : 'Sign Up')}
                     </button>
                 </form>
                 <div className="mt-6 text-center">
-                    <button onClick={() => setIsLoginView(!isLoginView)} className="font-medium text-blue-600 hover:text-blue-500">
+                    <button onClick={() => setIsLoginView(!isLoginView)} className="font-medium text-sky-600 hover:text-sky-500">
                         {isLoginView ? "Don't have an account? Sign Up" : "Already have an account? Sign In"}
                     </button>
                 </div>
@@ -332,50 +332,50 @@ const AdminDashboard = ({ userToken }) => {
     };
 
     if (loading) {
-        return <div className="flex justify-center items-center p-8"><Loader2 className="animate-spin h-8 w-8 text-blue-600" /></div>;
+        return <div className="flex justify-center items-center p-8"><Loader2 className="animate-spin h-8 w-8 text-sky-500" /></div>;
     }
 
     return (
         <div className="space-y-8">
-            <h2 className="text-3xl font-bold text-gray-800">Admin Dashboard</h2>
+            <h2 className="text-3xl font-bold text-slate-700">Admin Dashboard</h2>
             <Alert type="error" message={error} />
             <Alert type="success" message={success} />
-            
-            <section className="p-6 bg-gray-50 rounded-xl border">
-                <h3 className="text-xl font-semibold mb-4">Service Fee Configuration</h3>
+
+            <section className="p-6 bg-white/90 rounded-2xl border border-sky-100 shadow-sm">
+                <h3 className="text-xl font-semibold text-slate-700 mb-4">Service Fee Configuration</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
-                        <label htmlFor="b2c_fee" className="block text-sm font-medium text-gray-700">B2C Service Fee ($)</label>
-                        <input type="number" step="0.01" id="b2c_fee" value={settings.service_fee_b2c} onChange={e => setSettings({...settings, service_fee_b2c: e.target.value})} className="w-full mt-1 p-3 border rounded-lg" />
+                        <label htmlFor="b2c_fee" className="block text-sm font-medium text-slate-600">B2C Service Fee ($)</label>
+                        <input type="number" step="0.01" id="b2c_fee" value={settings.service_fee_b2c} onChange={e => setSettings({...settings, service_fee_b2c: e.target.value})} className="w-full mt-1 p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
                     </div>
                     <div>
-                        <label htmlFor="b2b_fee" className="block text-sm font-medium text-gray-700">B2B Service Fee ($)</label>
-                        <input type="number" step="0.01" id="b2b_fee" value={settings.service_fee_b2b} onChange={e => setSettings({...settings, service_fee_b2b: e.target.value})} className="w-full mt-1 p-3 border rounded-lg" />
+                        <label htmlFor="b2b_fee" className="block text-sm font-medium text-slate-600">B2B Service Fee ($)</label>
+                        <input type="number" step="0.01" id="b2b_fee" value={settings.service_fee_b2b} onChange={e => setSettings({...settings, service_fee_b2b: e.target.value})} className="w-full mt-1 p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
                     </div>
                 </div>
                 <div className="mt-6 text-right">
-                    <button onClick={handleSaveSettings} className="py-2 px-6 rounded-lg font-bold text-white bg-blue-600 hover:bg-blue-700">Save Settings</button>
+                    <button onClick={handleSaveSettings} className="py-2 px-6 rounded-xl font-semibold text-white bg-sky-500 hover:bg-sky-400 transition-colors">Save Settings</button>
                 </div>
             </section>
 
-            <section className="p-6 bg-gray-50 rounded-xl border">
-                 <h3 className="text-xl font-semibold mb-4">User Management</h3>
+            <section className="p-6 bg-white/90 rounded-2xl border border-sky-100 shadow-sm">
+                 <h3 className="text-xl font-semibold text-slate-700 mb-4">User Management</h3>
                  <div className="overflow-x-auto">
-                     <table className="min-w-full divide-y divide-gray-200">
-                         <thead className="bg-gray-100">
+                     <table className="min-w-full divide-y divide-slate-200">
+                         <thead className="bg-sky-50">
                              <tr>
-                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
-                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
-                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                                 <th className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Email</th>
+                                 <th className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Role</th>
+                                 <th className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Actions</th>
                              </tr>
                          </thead>
-                         <tbody className="bg-white divide-y divide-gray-200">
+                         <tbody className="bg-white divide-y divide-slate-100">
                              {users.map(user => (
                                  <tr key={user.uid}>
                                      <td className="px-6 py-4 whitespace-nowrap">{user.email}</td>
                                      <td className="px-6 py-4 whitespace-nowrap">{user.role}</td>
                                      <td className="px-6 py-4 whitespace-nowrap">
-                                         <select onChange={(e) => handleRoleChange(user.uid, e.target.value)} defaultValue={user.role} className="p-2 border rounded-lg">
+                                         <select onChange={(e) => handleRoleChange(user.uid, e.target.value)} defaultValue={user.role} className="p-2 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400">
                                              <option value="b2c">B2C</option>
                                              <option value="b2b">B2B</option>
                                              <option value="admin">Admin</option>
@@ -430,39 +430,39 @@ const AddressForm = ({ type, values, setters }) => {
     }, [suggestionsRef]);
 
     return (
-        <section className="p-6 bg-blue-50 rounded-xl border border-blue-100">
-            <h2 className="text-2xl font-semibold text-gray-700 mb-6 flex items-center"><MapPin className="mr-3 text-blue-500" size={24} /> {title} Info</h2>
+        <section className="p-6 bg-white/90 rounded-2xl border border-sky-100 shadow-sm">
+            <h2 className="text-2xl font-semibold text-slate-700 mb-6 flex items-center"><MapPin className="mr-3 text-sky-500" size={24} /> {title} Info</h2>
             <div className="grid grid-cols-1 gap-6">
-                <input required value={values.name} onChange={e => setters.setName(e.target.value)} placeholder="Name" className="w-full p-3 border rounded-lg" />
-                <input value={values.company} onChange={e => setters.setCompany(e.target.value)} placeholder="Company (Optional)" className="w-full p-3 border rounded-lg" />
+                <input required value={values.name} onChange={e => setters.setName(e.target.value)} placeholder="Name" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
+                <input value={values.company} onChange={e => setters.setCompany(e.target.value)} placeholder="Company (Optional)" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
                 <div className="relative" ref={suggestionsRef}>
-                    <input required value={values.street1} onChange={handleStreet1Change} placeholder="Street 1" className="w-full p-3 border rounded-lg" />
-                    {isSearching && <Loader2 className="animate-spin absolute right-3 top-3 text-gray-400" />}
+                    <input required value={values.street1} onChange={handleStreet1Change} placeholder="Street 1" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
+                    {isSearching && <Loader2 className="animate-spin absolute right-3 top-3 h-5 w-5 text-sky-500" />}
                     {suggestions.length > 0 && (
-                        <ul className="absolute z-10 w-full bg-white border rounded-lg mt-1 shadow-lg max-h-60 overflow-y-auto">
+                        <ul className="absolute z-10 w-full bg-white border border-sky-100 rounded-xl mt-1 shadow-lg max-h-60 overflow-y-auto">
                             {suggestions.map((s, index) => (
-                                <li key={index} onClick={() => handleSuggestionClick(s)} className="p-3 hover:bg-gray-100 cursor-pointer">{s.description}</li>
+                                <li key={index} onClick={() => handleSuggestionClick(s)} className="p-3 hover:bg-sky-50 cursor-pointer">{s.description}</li>
                             ))}
                         </ul>
                     )}
                 </div>
-                <input value={values.street2} onChange={e => setters.setStreet2(e.target.value)} placeholder="Street 2" className="w-full p-3 border rounded-lg" />
+                <input value={values.street2} onChange={e => setters.setStreet2(e.target.value)} placeholder="Street 2" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-                    <input required value={values.city} onChange={e => setters.setCity(e.target.value)} placeholder="City" className="w-full p-3 border rounded-lg" />
-                    <select required value={values.state} onChange={e => setters.setState(e.target.value)} className="w-full p-3 border rounded-lg bg-white text-base">
+                    <input required value={values.city} onChange={e => setters.setCity(e.target.value)} placeholder="City" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
+                    <select required value={values.state} onChange={e => setters.setState(e.target.value)} className="w-full p-3 border border-slate-200 rounded-xl bg-white text-base focus:ring-2 focus:ring-sky-200 focus:border-sky-400">
                         <option value="">Select State</option>
                         {usStates.map(state => <option key={state.abbreviation} value={state.abbreviation}>{state.abbreviation}</option>)}
                     </select>
-                    <input required value={values.zip} onChange={e => setters.setZip(e.target.value)} placeholder="Zip Code" pattern="[0-9]{5}" title="Enter a 5-digit zip code" className="w-full p-3 border rounded-lg" />
+                    <input required value={values.zip} onChange={e => setters.setZip(e.target.value)} placeholder="Zip Code" pattern="[0-9]{5}" title="Enter a 5-digit zip code" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
                 </div>
                 {type === 'destination' && (
                     <div className="mt-4">
-                      <label className="block text-base font-medium text-gray-700 mb-2">Address Type</label>
+                      <label className="block text-base font-medium text-slate-600 mb-2">Address Type</label>
                       <div className="flex items-center">
-                        <button type="button" role="switch" aria-checked={!values.isResidential} onClick={() => setters.setIsResidential(!values.isResidential)} className={`${!values.isResidential ? 'bg-blue-600' : 'bg-gray-200'} relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2`}>
+                        <button type="button" role="switch" aria-checked={!values.isResidential} onClick={() => setters.setIsResidential(!values.isResidential)} className={`${!values.isResidential ? 'bg-sky-500' : 'bg-slate-200'} relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-sky-200 focus:ring-offset-2`}>
                           <span aria-hidden="true" className={`${!values.isResidential ? 'translate-x-5' : 'translate-x-0'} pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out`} />
                         </button>
-                        <span className="ml-3 text-base font-medium text-gray-900">Commercial</span>
+                        <span className="ml-3 text-base font-medium text-slate-700">Commercial</span>
                       </div>
                     </div>
                 )}
@@ -485,36 +485,36 @@ const PackageForm = ({ values, setters, onOptionChange }) => {
     };
 
     return (
-        <section className="p-6 bg-blue-50 rounded-xl border border-blue-100">
-            <h2 className="text-2xl font-semibold text-gray-700 mb-6 flex items-center"><Package className="mr-3 text-blue-500" size={24} /> Package & Carrier</h2>
+        <section className="p-6 bg-white/90 rounded-2xl border border-sky-100 shadow-sm">
+            <h2 className="text-2xl font-semibold text-slate-700 mb-6 flex items-center"><Package className="mr-3 text-sky-500" size={24} /> Package & Carrier</h2>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-6">
                 <div className="relative">
-                    <input required min="0.1" value={values.weight} onChange={e => setters.setWeight(e.target.value)} placeholder="Weight" type="number" className="w-full p-3 border rounded-lg pr-12" />
-                    <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500">lbs</span>
+                    <input required min="0.1" value={values.weight} onChange={e => setters.setWeight(e.target.value)} placeholder="Weight" type="number" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 pr-12 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
+                    <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400">lbs</span>
                 </div>
                 <div className="relative">
-                    <input required min="1" value={values.length} onChange={e => setters.setLength(e.target.value)} placeholder="Length" type="number" className="w-full p-3 border rounded-lg pr-10" />
-                    <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500">in</span>
+                    <input required min="1" value={values.length} onChange={e => setters.setLength(e.target.value)} placeholder="Length" type="number" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 pr-10 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
+                    <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400">in</span>
                 </div>
                 <div className="relative">
-                    <input required min="1" value={values.width} onChange={e => setters.setWidth(e.target.value)} placeholder="Width" type="number" className="w-full p-3 border rounded-lg pr-10" />
-                    <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500">in</span>
+                    <input required min="1" value={values.width} onChange={e => setters.setWidth(e.target.value)} placeholder="Width" type="number" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 pr-10 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
+                    <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400">in</span>
                 </div>
                 <div className="relative">
-                    <input required min="1" value={values.height} onChange={e => setters.setHeight(e.target.value)} placeholder="Height" type="number" className="w-full p-3 border rounded-lg pr-10" />
-                    <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500">in</span>
+                    <input required min="1" value={values.height} onChange={e => setters.setHeight(e.target.value)} placeholder="Height" type="number" className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 pr-10 focus:ring-2 focus:ring-sky-200 focus:border-sky-400" />
+                    <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400">in</span>
                 </div>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mt-6">
-                <div className="flex items-center bg-white p-3 border rounded-lg sm:col-span-1">
+                <div className="flex items-center bg-white/80 p-3 border border-slate-200 rounded-xl sm:col-span-1">
                     <img src="/Fedex-logo.png"/>
-                    <span className="text-base font-medium text-gray-700">{carrierDetailsMap.fedex.name}</span>
+                    <span className="ml-3 text-base font-medium text-slate-600">{carrierDetailsMap.fedex.name}</span>
                 </div>
-                <select required value={values.selectedServiceCode} onChange={handleServiceChange} className="w-full p-3 border rounded-lg text-base bg-white sm:col-span-1">
+                <select required value={values.selectedServiceCode} onChange={handleServiceChange} className="w-full p-3 border border-slate-200 rounded-xl text-base bg-white focus:ring-2 focus:ring-sky-200 focus:border-sky-400 sm:col-span-1">
                     <option value="">Select Service</option>
                     {carrierDetailsMap.fedex.services.map(s => <option key={s.serviceCode} value={s.serviceCode}>{s.name}</option>)}
                 </select>
-                <select required value={values.packageCode} onChange={handlePackageChange} className="w-full p-3 border rounded-lg text-base bg-white sm:col-span-1">
+                <select required value={values.packageCode} onChange={handlePackageChange} className="w-full p-3 border border-slate-200 rounded-xl text-base bg-white focus:ring-2 focus:ring-sky-200 focus:border-sky-400 sm:col-span-1">
                     <option value="">Select Package Type</option>
                     {availablePackages.map(p => <option key={p.code} value={p.code}>{p.name}</option>)}
                 </select>
@@ -524,23 +524,23 @@ const PackageForm = ({ values, setters, onOptionChange }) => {
 };
 
 const Summary = ({ values }) => (
-    <section className="p-6 bg-gray-50 rounded-xl border">
-        <h2 className="text-2xl font-semibold text-gray-700 mb-6">Summary</h2>
-        <div className="space-y-4 text-gray-600">
+    <section className="p-6 bg-white/90 rounded-2xl border border-sky-100 shadow-sm">
+        <h2 className="text-2xl font-semibold text-slate-700 mb-6">Summary</h2>
+        <div className="space-y-4 text-slate-600">
             <div>
-                <h3 className="font-semibold text-gray-800">Origin</h3>
+                <h3 className="font-semibold text-slate-700">Origin</h3>
                 <p>{values.originName}, {values.originStreet1}, {values.originCity}, {values.originState} {values.originZip}</p>
             </div>
             <div>
-                <h3 className="font-semibold text-gray-800">Destination</h3>
+                <h3 className="font-semibold text-slate-700">Destination</h3>
                 <p>{values.destinationName}, {values.destinationStreet1}, {values.destinationCity}, {values.destinationState} {values.destinationZip}</p>
             </div>
             <div>
-                <h3 className="font-semibold text-gray-800">Package</h3>
+                <h3 className="font-semibold text-slate-700">Package</h3>
                 <p>{values.weight} lbs, {values.length}x{values.width}x{values.height} in</p>
             </div>
              <div>
-                <h3 className="font-semibold text-gray-800">Service</h3>
+                <h3 className="font-semibold text-slate-700">Service</h3>
                 <p>{carrierDetailsMap.fedex.services.find(s => s.serviceCode === values.selectedServiceCode)?.name || 'N/A'}</p>
             </div>
         </div>
@@ -553,7 +553,7 @@ const Stepper = ({ currentStep, steps }) => (
             <div className="flex items-center">
                 {steps.map((step, stepIdx) => (
                     <li key={step.name} className={`flex-1 ${stepIdx !== steps.length - 1 ? 'pr-8 sm:pr-20' : ''}`}>
-                        <div className={`text-center text-sm font-medium ${stepIdx <= currentStep ? 'text-blue-600' : 'text-gray-500'}`}>
+                        <div className={`text-center text-sm font-medium ${stepIdx <= currentStep ? 'text-sky-600' : 'text-slate-400'}`}>
                             {step.name}
                         </div>
                     </li>
@@ -565,27 +565,27 @@ const Stepper = ({ currentStep, steps }) => (
                         {stepIdx < currentStep ? (
                             <>
                                 <div className="absolute inset-0 flex items-center" aria-hidden="true">
-                                    <div className="h-0.5 w-full bg-blue-600" />
+                                    <div className="h-0.5 w-full bg-sky-400" />
                                 </div>
-                                <span className="relative flex h-8 w-8 items-center justify-center bg-blue-600 rounded-full text-white mx-auto">
+                                <span className="relative flex h-8 w-8 items-center justify-center bg-sky-500 rounded-full text-white mx-auto">
                                     <CheckCircle className="h-5 w-5" />
                                 </span>
                             </>
                         ) : stepIdx === currentStep ? (
                             <>
                                 <div className="absolute inset-0 flex items-center" aria-hidden="true">
-                                    <div className="h-0.5 w-full bg-gray-200" />
+                                    <div className="h-0.5 w-full bg-slate-200" />
                                 </div>
-                                <span className="relative flex h-8 w-8 items-center justify-center bg-white border-2 border-blue-600 rounded-full mx-auto">
-                                    <span className="h-2.5 w-2.5 bg-blue-600 rounded-full" />
+                                <span className="relative flex h-8 w-8 items-center justify-center bg-white border-2 border-sky-400 rounded-full mx-auto">
+                                    <span className="h-2.5 w-2.5 bg-sky-400 rounded-full" />
                                 </span>
                             </>
                         ) : (
                             <>
                                 <div className="absolute inset-0 flex items-center" aria-hidden="true">
-                                    <div className="h-0.5 w-full bg-gray-200" />
+                                    <div className="h-0.5 w-full bg-slate-200" />
                                 </div>
-                                <span className="relative flex h-8 w-8 items-center justify-center bg-white border-2 border-gray-300 rounded-full mx-auto" />
+                                <span className="relative flex h-8 w-8 items-center justify-center bg-white border-2 border-slate-200 rounded-full mx-auto" />
                             </>
                         )}
                     </li>
@@ -809,37 +809,37 @@ const App = () => {
 
 
   if (authLoading) {
-    return <div className="min-h-screen flex items-center justify-center"><Loader2 className="animate-spin h-12 w-12 text-blue-600" /></div>;
+    return <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-white via-sky-50 to-emerald-50"><Loader2 className="animate-spin h-12 w-12 text-sky-500" /></div>;
   }
 
   return (
-    <div className="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen font-sans">
+    <div className="bg-gradient-to-br from-white via-sky-50 to-emerald-50 min-h-screen font-sans text-slate-700">
       <LoginPage show={showLogin} onClose={() => setShowLogin(false)} />
 
-      <nav className="fixed top-0 left-0 right-0 bg-gray-700 shadow-md z-20">
+      <nav className="fixed top-0 left-0 right-0 bg-white/80 backdrop-blur-md border-b border-sky-100 shadow-sm z-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between h-20">
                 <div className="flex-shrink-0">
                      <img src="/logo.png" alt="Company Logo" className="h-12 w-auto object-contain"/>
                 </div>
                 <div className="flex items-center">
-                    <h1 className="text-2xl lg:text-3xl font-bold text-white hidden sm:block">
+                    <h1 className="text-2xl lg:text-3xl font-bold text-slate-700 hidden sm:block">
                         Shipping Label Creator
                     </h1>
                     {userToken ? (
                         <>
                            {userRole === 'admin' && (
-                                <button onClick={() => setCurrentView(currentView === 'admin' ? 'shipping' : 'admin')} className="ml-4 p-2 rounded-lg text-white font-semibold bg-blue-600 hover:bg-blue-700 flex items-center">
+                                <button onClick={() => setCurrentView(currentView === 'admin' ? 'shipping' : 'admin')} className="ml-4 py-2 px-4 rounded-full text-white font-semibold bg-sky-500 hover:bg-sky-400 flex items-center shadow-sm">
                                     <Settings className="h-5 w-5 mr-2" />
                                     {currentView === 'admin' ? 'Go to App' : 'Dashboard'}
                                 </button>
                            )}
-                            <button onClick={handleSignOut} className="ml-4 p-2 rounded-full text-white hover:bg-gray-600">
+                            <button onClick={handleSignOut} className="ml-4 p-2 rounded-full text-slate-500 hover:bg-slate-100 transition-colors">
                                 <LogOut className="h-6 w-6" />
                             </button>
                         </>
                     ) : (
-                        <button onClick={() => setShowLogin(true)} className="ml-4 p-2 rounded-lg text-white font-semibold bg-blue-600 hover:bg-blue-700 flex items-center">
+                        <button onClick={() => setShowLogin(true)} className="ml-4 py-2 px-4 rounded-full text-white font-semibold bg-sky-500 hover:bg-sky-400 flex items-center shadow-sm">
                             <LogIn className="h-5 w-5 mr-2" /> Login
                         </button>
                     )}
@@ -847,9 +847,9 @@ const App = () => {
             </div>
         </div>
       </nav>
-      
+
       <main className="pt-28 pb-8">
-        <div className="bg-white p-6 sm:p-8 rounded-xl shadow-2xl w-full max-w-full md:max-w-4xl lg:max-w-6xl border border-blue-200 mx-auto">
+        <div className="bg-white/90 p-6 sm:p-10 rounded-3xl shadow-xl w-full max-w-full md:max-w-4xl lg:max-w-6xl border border-sky-100 mx-auto backdrop-blur">
             {currentView === 'admin' && userRole === 'admin' ? (
                 <AdminDashboard userToken={userToken} />
             ) : (
@@ -866,7 +866,7 @@ const App = () => {
                                         values={{ name: originName, company: originCompany, street1: originStreet1, street2: originStreet2, city: originCity, state: originState, zip: originZip }}
                                         setters={{ setName: setOriginName, setCompany: setOriginCompany, setStreet1: setOriginStreet1, setStreet2: setOriginStreet2, setCity: setOriginCity, setState: setOriginState, setZip: setOriginZip }}
                                     />
-                                    <button onClick={nextStep} className="w-full py-4 px-6 rounded-lg font-bold text-white bg-blue-600 hover:bg-blue-700 flex items-center justify-center text-lg active:scale-95 transition-transform">
+                                    <button onClick={nextStep} className="w-full py-4 px-6 rounded-full font-semibold text-white bg-sky-500 hover:bg-sky-400 flex items-center justify-center text-lg active:scale-95 transition-transform shadow-sm">
                                         Next: Destination <ArrowRight className="ml-2" />
                                     </button>
                                 </div>
@@ -884,11 +884,11 @@ const App = () => {
                                         setters={{ setWeight, setLength, setWidth, setHeight, setSelectedServiceCode, setPackageCode }}
                                         onOptionChange={handleOptionChange}
                                     />
-                                    <div className="flex justify-between">
-                                        <button onClick={prevStep} className="py-4 px-6 rounded-lg font-bold text-gray-700 bg-gray-200 hover:bg-gray-300 flex items-center justify-center text-lg active:scale-95 transition-transform">
+                                    <div className="flex justify-between gap-4">
+                                        <button onClick={prevStep} className="flex-1 py-4 px-6 rounded-full font-semibold text-slate-600 bg-white border border-slate-200 hover:bg-slate-100 flex items-center justify-center text-lg active:scale-95 transition-transform shadow-sm">
                                             <ArrowLeft className="mr-2" /> Back
                                         </button>
-                                        <button onClick={nextStep} className="py-4 px-6 rounded-lg font-bold text-white bg-blue-600 hover:bg-blue-700 flex items-center justify-center text-lg active:scale-95 transition-transform">
+                                        <button onClick={nextStep} className="flex-1 py-4 px-6 rounded-full font-semibold text-white bg-sky-500 hover:bg-sky-400 flex items-center justify-center text-lg active:scale-95 transition-transform shadow-sm">
                                             Next: Review & Create <ArrowRight className="ml-2" />
                                         </button>
                                     </div>
@@ -899,7 +899,7 @@ const App = () => {
                                  <div className="grid lg:grid-cols-2 gap-8">
                                     <div className="lg:col-span-1 flex flex-col space-y-8">
                                         <Summary values={getShipmentDetails()} />
-                                        <button onClick={prevStep} className="w-full py-4 px-6 rounded-lg font-bold text-gray-700 bg-gray-200 hover:bg-gray-300 flex items-center justify-center text-lg active:scale-95 transition-transform">
+                                        <button onClick={prevStep} className="w-full py-4 px-6 rounded-full font-semibold text-slate-600 bg-white border border-slate-200 hover:bg-slate-100 flex items-center justify-center text-lg active:scale-95 transition-transform shadow-sm">
                                             <ArrowLeft className="mr-2" /> Back to Edit
                                         </button>
                                     </div>
@@ -909,34 +909,34 @@ const App = () => {
                                         <Alert type="success" message={orderSendSuccess} />
                                         
                                         {shippingCost === null && !orderSendSuccess && (
-                                             <button onClick={handleCalculateShipping} disabled={loading} className="w-full py-4 px-6 rounded-lg font-bold text-white bg-blue-600 hover:bg-blue-700 flex items-center justify-center text-lg active:scale-95 transition-transform">
+                                             <button onClick={handleCalculateShipping} disabled={loading} className="w-full py-4 px-6 rounded-full font-semibold text-white bg-sky-500 hover:bg-sky-400 flex items-center justify-center text-lg active:scale-95 transition-transform shadow-sm disabled:bg-slate-300 disabled:text-slate-500">
                                                 {loading ? <><Loader2 className="animate-spin mr-3" size={24} />Calculating...</> : <><DollarSign className="mr-3" size={24} />Calculate Shipping</>}
                                             </button>
                                         )}
 
                                         {shippingCost !== null && !orderSendSuccess && (
-                                            <div className="text-center p-6 bg-green-50 rounded-xl border border-green-200">
-                                                <h2 className="text-2xl font-bold text-green-700 mb-3">Total Estimated Cost</h2>
-                                                <p className="text-5xl font-extrabold text-green-800">${shippingCost.toFixed(2)}</p>
-                                                <div className="mt-4 text-green-700 space-y-1">
+                                            <div className="text-center p-6 bg-emerald-50 rounded-2xl border border-emerald-200 shadow-sm">
+                                                <h2 className="text-2xl font-bold text-emerald-700 mb-3">Total Estimated Cost</h2>
+                                                <p className="text-5xl font-extrabold text-emerald-800">${shippingCost.toFixed(2)}</p>
+                                                <div className="mt-4 text-emerald-700 space-y-1">
                                                     <p>Base Rate: ${baseShippingCost !== null ? baseShippingCost.toFixed(2) : '0.00'}</p>
                                                     <p>Service Fee: ${appliedServiceFee ? appliedServiceFee.toFixed(2) : '0.00'}</p>
                                                 </div>
 
                                                 {userToken ? (
-                                                    <button onClick={handleCreateOrder} disabled={orderSending} className="mt-6 w-full py-4 px-6 rounded-lg font-bold text-white bg-purple-600 hover:bg-purple-700">
+                                                    <button onClick={handleCreateOrder} disabled={orderSending} className="mt-6 w-full py-4 px-6 rounded-full font-semibold text-white bg-emerald-500 hover:bg-emerald-400 shadow-sm disabled:bg-emerald-200">
                                                         {orderSending ? 'Creating Order...' : 'Create Shipping Label'}
                                                     </button>
                                                 ) : (
-                                                    <button onClick={() => setShowLogin(true)} className="mt-6 w-full py-4 px-6 rounded-lg font-bold text-white bg-green-600 hover:bg-green-700">
+                                                    <button onClick={() => setShowLogin(true)} className="mt-6 w-full py-4 px-6 rounded-full font-semibold text-white bg-emerald-500 hover:bg-emerald-400 shadow-sm">
                                                         Login to Create Label
                                                     </button>
                                                 )}
                                             </div>
                                         )}
-                                        
+
                                         {orderSendSuccess && (
-                                            <button onClick={handleCreateAnother} className="w-full py-4 px-6 rounded-lg font-bold text-white bg-blue-600 hover:bg-blue-700 flex items-center justify-center text-lg active:scale-95 transition-transform">
+                                            <button onClick={handleCreateAnother} className="w-full py-4 px-6 rounded-full font-semibold text-white bg-sky-500 hover:bg-sky-400 flex items-center justify-center text-lg active:scale-95 transition-transform shadow-sm">
                                                 Create Another Shipment
                                             </button>
                                         )}


### PR DESCRIPTION
## Summary
- restyle alerts, dialogs, and data tables with softer colors and rounded corners
- lighten address, package, and summary cards plus navigation/header for a minimal pastel look
- refresh action buttons and steppers to match the simplified light theme and improve focus states

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cc2a82c7948320aed86073ccfb8eb6