### PR TITLE
Normalize role strings and test admin route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -158,15 +158,22 @@ const debounce = (func, delay) => {
     };
 };
 
-const deriveRoleFromClaims = (claims = {}) => {
-    if (typeof claims.role === 'string' && claims.role.trim()) {
-        return claims.role.trim().toLowerCase();
+export const deriveRoleFromClaims = (claims = {}) => {
+    if (typeof claims.role === 'string') {
+        const trimmedRole = claims.role.trim();
+        if (trimmedRole) {
+            return trimmedRole.toLowerCase();
+        }
     }
 
     const prioritizedRoles = ['admin', 'b2b', 'b2c'];
 
     if (Array.isArray(claims.roles) && claims.roles.length) {
-        const normalizedRoles = new Set(claims.roles.map(role => String(role).toLowerCase()));
+        const normalizedRoles = new Set(
+            claims.roles
+                .map(role => String(role).trim().toLowerCase())
+                .filter(Boolean)
+        );
         for (const role of prioritizedRoles) {
             if (normalizedRoles.has(role)) return role;
         }
@@ -619,8 +626,8 @@ const Stepper = ({ currentStep, steps }) => (
 
 
 // --- Route Guards ---
-const AdminRoute = ({ userRole, userToken, children }) => {
-  const isAdmin = typeof userRole === 'string' && userRole.toLowerCase() === 'admin';
+export const AdminRoute = ({ userRole, userToken, children }) => {
+  const isAdmin = typeof userRole === 'string' && userRole.trim().toLowerCase() === 'admin';
 
   if (!userToken || !isAdmin) {
     return <Navigate to="/" replace />;
@@ -695,7 +702,7 @@ const App = () => {
         const idTokenResult = await user.getIdTokenResult();
         const claims = idTokenResult?.claims ?? {};
         const derivedRole = deriveRoleFromClaims(claims);
-        const normalizedRole = derivedRole ? String(derivedRole).toLowerCase() : null;
+        const normalizedRole = derivedRole ? String(derivedRole).trim().toLowerCase() : null;
 
         setUserToken(idTokenResult.token);
         setUserRole(normalizedRole || 'b2c');
@@ -1006,4 +1013,5 @@ const App = () => {
     </div>
   );
 };
+
 export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,4 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import * as AppModule from './App';
+
+const App = AppModule.default;
+const { deriveRoleFromClaims, AdminRoute } = AppModule;
 
 jest.mock('firebase/app', () => ({
   __esModule: true,
@@ -17,10 +21,27 @@ jest.mock('firebase/auth', () => ({
   signInWithEmailAndPassword: jest.fn(),
 }));
 
-const App = require('./App').default;
-
 test('renders app title', async () => {
   render(<App />);
   const heading = await screen.findByText(/Shipping Label Creator/i);
   expect(heading).toBeInTheDocument();
+});
+
+test('derives and applies trimmed admin role', () => {
+  const derivedRole = deriveRoleFromClaims({ role: '  Admin ' });
+
+  const routeContent = AdminRoute({
+    userRole: derivedRole,
+    userToken: 'token',
+    children: <div>Admin Area</div>,
+  });
+
+  expect(derivedRole).toBe('admin');
+  expect(routeContent).toEqual(<div>Admin Area</div>);
+});
+
+test('derives admin role from roles array containing whitespace', () => {
+  const derivedRole = deriveRoleFromClaims({ roles: ['  admin  '] });
+
+  expect(derivedRole).toBe('admin');
 });


### PR DESCRIPTION
## Summary
- trim role strings when deriving and storing user roles so whitespace is removed, including entries within the roles array
- ensure AdminRoute comparisons use trimmed values
- add unit tests verifying whitespace-padded admin roles are accepted

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cf321db1d083209c819c14d81717ac